### PR TITLE
varcheck has moved to gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Sponsored by [GolangCI](https://golangci.com): SaaS service for running linters 
 * [structcheck](https://github.com/opennota/check) - Find unused global variables and constants.
 * [unparam](https://github.com/mvdan/unparam) - Report unused function parameters.
 * [unused](https://github.com/dominikh/go-tools/tree/master/cmd/unused) - unused checks Go code for unused constants, variables, functions and types.
-* [varcheck](https://github.com/opennota/check) - Find unused global variables and constants.
+* [varcheck](https://gitlab.com/opennota/check) - Find unused global variables and constants.
 
 ### Performance
 * [aligncheck](https://github.com/opennota/check) - Warn about un-optimally aligned structures.


### PR DESCRIPTION
According to the README.md on https://github.com/opennota/check, this repo has moved to gitlab.com.