### PR TITLE
Add SourceLevel to General Purpose section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Sponsored by [GolangCI](https://golangci.com): SaaS service for running linters 
 * [QuantifiedCode](https://www.quantifiedcode.com/) - Automated code review & repair
 * [Scrutinizer](https://scrutinizer-ci.com/) - A proprietery code quality checker that can be integrated with GitHub
 * [SideCI](https://sideci.com/) - An automated code reviewing tool. Improving developers' productivity.
-
+* [SourceLevel](https://sourcelevel.io/) - Automated Code Review and Pull Request Metrics
 
 ## Linters
 ### Code Formatting


### PR DESCRIPTION
This PR adds [SourceLevel](https://sourcelevel.io) to `General Purpose` section.

SourceLevel supports Golang related tools:

- [gofmt](https://docs.sourcelevel.io/engines/gofmt/)
- [govet](https://docs.sourcelevel.io/engines/govet/)
- [golint](https://docs.sourcelevel.io/engines/golint/)

[View all supported engines in our docs](https://docs.sourcelevel.io/engines/)

### Additional information

- [x] Removes extra empty line from `General Purpose` section